### PR TITLE
fix(ci): 修复 GitHub Pages 部署工作流

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,8 @@ on:
 
 permissions:
   contents: read
+  pages: write
+  id-token: write
 
 concurrency:
   group: pages-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,11 +9,9 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: pages-${{ github.ref }}
+  group: pages-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -22,6 +20,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Configure GitHub Pages
+        id: pages
+        uses: actions/configure-pages@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -38,9 +40,8 @@ jobs:
       - name: Build documentation
         run: npm run docs:build
 
-      - name: Upload Pages artifact
-        if: github.event_name == 'push'
-        uses: actions/upload-pages-artifact@v3
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs/.vuepress/dist
 
@@ -48,6 +49,9 @@ jobs:
     if: github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## 问题

合并文档 PR 后，Pull Request 的构建检查虽然通过，但 `main` 推送触发的 GitHub Pages 部署失败。原工作流没有执行官方推荐的 `actions/configure-pages`，并仍使用 `actions/upload-pages-artifact@v3`。

## 修改

- 增加 `actions/configure-pages@v5`；
- 升级为 `actions/upload-pages-artifact@v4`；
- 在 Pull Request 中同样完成 Pages 配置检查和构件打包；
- 将 `pages: write` 与 `id-token: write` 权限收敛到部署作业；
- 保留 `main` 推送时才执行正式部署；
- 调整并发组，避免不同分支的检查相互取消。

## 依据

工作流结构与 GitHub 官方自定义 Pages 工作流保持一致：Configure Pages → 构建 → Upload Pages Artifact → Deploy Pages。
