### PR TITLE
fix(ui): 修复 logo 与第2章侧栏层级

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -13,14 +13,55 @@ const guideSidebar = [
     text: '第 2 章　入门——简明教程',
     collapsible: true,
     children: [
-      '/guide/02-getting-started.html',
-      '/guide/02-1-files.html',
-      '/guide/02-2-keywords-defaults.html',
-      '/guide/02-4-control-source.html',
-      '/guide/02-4-receptor-met-output.html',
-      '/guide/02-4-debug.html',
-      '/guide/02-4-results.html',
-      '/guide/02-5-modify.html',
+      { text: '本章导读', link: '/guide/02-getting-started.html' },
+      { text: '2.1　输入与输出文件控制', link: '/guide/02-1-files.html' },
+      {
+        text: '2.2　关键字/参数方式说明',
+        link: '/guide/02-2-keywords-defaults.html#_2-2-关键字-参数方式说明',
+      },
+      {
+        text: '2.3　法规默认模拟选项',
+        link: '/guide/02-2-keywords-defaults.html#_2-3-法规默认模拟选项',
+      },
+      {
+        text: '2.4　建立一个简单控制文件',
+        collapsible: true,
+        children: [
+          {
+            text: '2.4.1　简单工业污染源应用',
+            link: '/guide/02-4-control-source.html#_2-4-1-简单工业污染源应用',
+          },
+          {
+            text: '2.4.2　选择模拟选项——CO 路径',
+            link: '/guide/02-4-control-source.html#_2-4-2-选择模拟选项-co-路径',
+          },
+          {
+            text: '2.4.3　指定污染源输入——SO 路径',
+            link: '/guide/02-4-control-source.html#_2-4-3-指定污染源输入-so-路径',
+          },
+          {
+            text: '2.4.4　指定受体网络——RE 路径',
+            link: '/guide/02-4-receptor-met-output.html#_2-4-4-指定受体网络-re-路径',
+          },
+          {
+            text: '2.4.5　指定气象输入——ME 路径',
+            link: '/guide/02-4-receptor-met-output.html#_2-4-5-指定气象输入-me-路径',
+          },
+          {
+            text: '2.4.6　选择输出选项——OU 路径',
+            link: '/guide/02-4-receptor-met-output.html#_2-4-6-选择输出选项-ou-路径',
+          },
+          {
+            text: '2.4.7　错误消息与调试',
+            link: '/guide/02-4-debug.html',
+          },
+          {
+            text: '2.4.8　运行模型并检查结果',
+            link: '/guide/02-4-results.html',
+          },
+        ],
+      },
+      { text: '2.5　修改已有控制文件', link: '/guide/02-5-modify.html' },
     ],
   },
   {
@@ -80,6 +121,7 @@ export default defineUserConfig({
   head: [
     ['meta', { name: 'theme-color', content: '#1769aa' }],
     ['meta', { name: 'keywords', content: 'AERMOD,AERMET,AERMAP,大气扩散模型,中文文档' }],
+    ['link', { rel: 'icon', href: '/AERMODDoc/images/aermod2.svg' }],
   ],
   plugins: [
     nprogressPlugin(),
@@ -91,7 +133,7 @@ export default defineUserConfig({
     }),
   ],
   theme: defaultTheme({
-    logo: '/images/aermod2.svg',
+    logo: '/AERMODDoc/images/aermod2.svg',
     repo: 'hujinghaoabcd/AERMODDoc',
     docsDir: 'docs',
     lastUpdated: true,

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -133,7 +133,7 @@ export default defineUserConfig({
     }),
   ],
   theme: defaultTheme({
-    logo: '/AERMODDoc/images/aermod2.svg',
+    logo: '/images/aermod2.svg',
     repo: 'hujinghaoabcd/AERMODDoc',
     docsDir: 'docs',
     lastUpdated: true,

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -33,23 +33,23 @@ const guideSidebar = [
           },
           {
             text: '2.4.2　选择模拟选项——CO 路径',
-            link: '/guide/02-4-control-source.html#_2-4-2-选择模拟选项-co-路径',
+            link: '/guide/02-4-control-source.html#_2-4-2-选择模拟选项——co-路径',
           },
           {
             text: '2.4.3　指定污染源输入——SO 路径',
-            link: '/guide/02-4-control-source.html#_2-4-3-指定污染源输入-so-路径',
+            link: '/guide/02-4-control-source.html#_2-4-3-指定污染源输入——so-路径',
           },
           {
             text: '2.4.4　指定受体网络——RE 路径',
-            link: '/guide/02-4-receptor-met-output.html#_2-4-4-指定受体网络-re-路径',
+            link: '/guide/02-4-receptor-met-output.html#_2-4-4-指定受体网络——re-路径',
           },
           {
             text: '2.4.5　指定气象输入——ME 路径',
-            link: '/guide/02-4-receptor-met-output.html#_2-4-5-指定气象输入-me-路径',
+            link: '/guide/02-4-receptor-met-output.html#_2-4-5-指定气象输入——me-路径',
           },
           {
             text: '2.4.6　选择输出选项——OU 路径',
-            link: '/guide/02-4-receptor-met-output.html#_2-4-6-选择输出选项-ou-路径',
+            link: '/guide/02-4-receptor-met-output.html#_2-4-6-选择输出选项——ou-路径',
           },
           {
             text: '2.4.7　错误消息与调试',

--- a/docs/.vuepress/public/images/aermod2.svg
+++ b/docs/.vuepress/public/images/aermod2.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="8.5359097mm"
+   height="8.1491604mm"
+   viewBox="0 0 8.5359096 8.1491604"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="aermod2.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#999999"
+     borderopacity="1"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="10.653345"
+     inkscape:cx="-5.5851001"
+     inkscape:cy="27.456164"
+     inkscape:window-width="2160"
+     inkscape:window-height="1334"
+     inkscape:window-x="-11"
+     inkscape:window-y="-11"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs id="defs1" />
+  <g
+     inkscape:label="图层 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-135.90902,-121.97292)">
+    <path
+       class="st0"
+       d="m 140.57312,126.84125 -0.89958,-2.93687 -0.89959,2.93687 -0.47625,1.56104 -0.52916,1.71979 h -1.77271 l 2.67229,-8.14916 h 2.2225 l 2.67229,8.14916 H 141.605 l -0.52917,-1.71979 z"
+       id="path1"
+       style="fill:#41b883;fill-opacity:1;stroke-width:0.264583" />
+    <path
+       id="XMLID_6_"
+       d="m 143.21785,126.03959 c 0.10667,-0.049 0.26677,0.049 0.3201,0.049 0.0534,0.049 -0.10666,0.049 -0.1601,0.0978 v 0.0488 c 0.10667,0 0.58684,0.0978 0.85358,0.24468 0,0.0978 0.0534,0.0488 0.10667,0.0488 l -0.10667,0.049 0.0534,0.049 c 0.0534,-0.0978 0.10666,0.049 0.1601,0.049 -0.37345,0.19573 -0.69355,0.19573 -1.067,0.19573 -0.0534,0 -0.21339,0.0978 -0.32009,0 -0.21339,0.049 -0.26675,0.049 -0.48016,0.049 -1.54712,0.19573 -2.93419,0.53826 -4.48134,1.02761 -0.58684,0.19573 -1.22703,0.5872 -1.81387,0.63612 -0.1601,0 -0.37345,-0.19573 -0.37345,-0.44039 0,-0.44041 0.21341,-0.78293 1.06699,-1.32121 0.4268,-0.24467 0.96029,-0.48933 1.44043,-0.63612 1.17369,-0.2936 2.34737,-0.48935 3.5744,-0.34254 0.37345,-0.0978 0.6402,-0.049 0.96029,0.0978 0.26674,0 0.1601,0.049 0.26674,0.0978"
+       style="fill:#35495e;fill-opacity:1;stroke-width:0.510936" />
+  </g>
+</svg>


### PR DESCRIPTION
## 修改内容

- 修正导航栏 logo 和 favicon 的部署路径，使其适配 `/AERMODDoc/` 项目站点；
- 第 2 章侧栏改为明确的章节层级；
- 删除 `2.2—2.3`、`2.4.1—2.4.3`、`2.4.4—2.4.6` 等区间式菜单名称；
- 分别列出 2.2、2.3 和 2.4.1—2.4.8；
- 将 2.4 设为可折叠父级，下面展示各具体小节；
- 保留原页面文件，避免破坏既有链接。
