### PR TITLE
docs: 完整导入第4章参考文献

### DIFF
--- a/docs/.vuepress/guide-sidebar.js
+++ b/docs/.vuepress/guide-sidebar.js
@@ -135,13 +135,19 @@ export const guideSidebar = [
     ]),
   ]),
   group('第 4 章　参考文献', '/guide/04-references.html', [
-    group('4.1　EPA 法规与用户指南', '/guide/04-references.html#_4-1-epa-法规与用户指南', [
-      leaf('4.1.1　法规与实施文件', '/guide/04-references.html#_4-1-1-法规与实施文件'),
-      leaf('4.1.2　模型与预处理器手册', '/guide/04-references.html#_4-1-2-模型与预处理器手册'),
+    group('4.1　AECOM—EPA', '/guide/04-references.html#ref-4-1', [
+      leaf('4.1.1　AECOM—Carruthers', '/guide/04-references.html#ref-4-1-1'),
+      leaf('4.1.2　EPA 1995—2015', '/guide/04-references.html#ref-4-1-2'),
+      leaf('4.1.3　EPA 2017—2023', '/guide/04-references.html#ref-4-1-3'),
     ]),
-    group('4.2　技术与学术文献', '/guide/04-references.html#_4-2-技术与学术文献', [
-      leaf('4.2.1　模型理论与性能', '/guide/04-references.html#_4-2-1-模型理论与性能'),
-      leaf('4.2.2　专题研究与扩展方法', '/guide/04-references.html#_4-2-2-专题研究与扩展方法'),
+    group('4.2　Hanna—Murray', '/guide/04-references.html#ref-4-2', [
+      leaf('4.2.1　Hanna—Heist', '/guide/04-references.html#ref-4-2-1'),
+      leaf('4.2.2　Luhar—Murray', '/guide/04-references.html#ref-4-2-2'),
+    ]),
+    group('4.3　Pandey—Yang', '/guide/04-references.html#ref-4-3', [
+      leaf('4.3.1　Pandey—Petersen', '/guide/04-references.html#ref-4-3-1'),
+      leaf('4.3.2　Qian—Snyder', '/guide/04-references.html#ref-4-3-2'),
+      leaf('4.3.3　Venkatram—Yang', '/guide/04-references.html#ref-4-3-3'),
     ]),
   ]),
 ]

--- a/docs/guide/04-references.md
+++ b/docs/guide/04-references.md
@@ -5,35 +5,152 @@ sidebarDepth: 3
 
 # 4.0 参考文献
 
-本章列出用户指南中常用的 EPA 法规文件、AERMOD 用户指南与技术文献。为与其他章节保持一致，文献按“章—节—小节”三级结构分类展示。完整书目信息仍以英文原版第 4 章为准。
+本章对应英文原文印刷页码 **4-1—4-5**，共收录 **48 条参考文献**。为便于在线阅读，目录按作者或机构名称的字母顺序分段；各文献仍保留原文的排列顺序和编号。
 
-## 4.1 EPA 法规与用户指南
+作者、机构、期刊、报告编号、卷期页码和 DOI 保留原文形式，英文题名译为中文。法规适用、版本确认和正式引用仍应核对英文原文及发布机构的正式文件。
 
-### 4.1.1 法规与实施文件
+> 本章的 4.1—4.3 及其小节是在线导航分组，并非英文原文新增的文献分类。
 
-1. **EPA, 2017b.** *Guideline on Air Quality Models*, Appendix W to 40 CFR Part 51.
-2. **EPA, 2023b.** *AERMOD Implementation Guide*. EPA-454/B-23-009.
+<a id="ref-4-1"></a>
 
-### 4.1.2 模型与预处理器手册
+## 4.1 AECOM—EPA
 
-1. **EPA, 2018.** *User's Guide for the AERMOD Terrain Preprocessor (AERMAP)*. EPA-454/B-18-004.
-2. **EPA, 2021.** *AERSCREEN User's Guide*. EPA-454/B-21-005.
-3. **EPA, 2023a.** *AERMOD Model Formulation*. EPA-454/B-23-010.
-4. **EPA, 2023c.** *User's Guide for the AERMOD Meteorological Preprocessor (AERMET)*. EPA-454/B-23-005.
-5. **EPA, 2023d.** *Incorporation and Evaluation of the RLINE Source Type in AERMOD for Mobile Source Applications*. EPA-2023/R-23-011.
+<a id="ref-4-1-1"></a>
 
-## 4.2 技术与学术文献
+### 4.1.1 AECOM—Carruthers（1—4）
 
-### 4.2.1 模型理论与性能
+1. **AECOM, 2010.** 《AERMOD 低风速评估研究结果》。AECOM Environment，Westford, Massachusetts。
 
-1. **Cimorelli, A. J., et al., 2005.** AERMOD: A dispersion model for industrial source applications. Part I: General model formulation and boundary layer characterization. *Journal of Applied Meteorology*, 44, 682–693.
-2. **Perry, S. G., et al., 2005.** AERMOD: A dispersion model for industrial source applications. Part II: Model performance against 17 field study databases. *Journal of Applied Meteorology*, 44, 694–708.
-3. **Schulman, L. L. and Scire, J. S., 1980.** Buoyant Line and Point Source Dispersion Model (BLP).
+2. **API, 2013.** 《用于 AERMOD 1 小时 NO₂ 模拟的环境比值法第 2 版（ARM2）：开发与评估报告》。American Petroleum Institute，Washington, DC。
 
-### 4.2.2 专题研究与扩展方法
+3. **Azzi, M. and Johnson, G., 1992.** 《通用反应集光化学烟雾机制导论》。第 11 届 Clean Air Conference、第四届 Regional IUAPPA Conference 论文集，Brisbane, Australia。
 
-1. **AECOM, 2010.** AERMOD Low Wind Speed Evaluation Study results. AECOM Environment, Westford, Massachusetts.
-2. **API, 2013.** Ambient Ratio Method Version 2 (ARM2) for use with AERMOD for 1-hour NO₂ Modeling: Development and Evaluation Report. American Petroleum Institute, Washington, DC.
-3. **Venkatram, A., et al., 2013.** Meteorological inputs for AERMOD: estimating surface friction velocity in low wind speed stable conditions.
+4. **Carruthers, D. J., Stocker, J. R., Ellis, A., Seaton, M. D. and Smith, S. E., 2017.** 《AERMOD 中显式 NOx 化学方法的评估》。*Journal of the Air & Waste Management Association*, 67(6), 702–712。
 
-[完整 EPA 官方资源入口](/resources/)
+<a id="ref-4-1-2"></a>
+
+### 4.1.2 EPA 1995—2015（5—17）
+
+5. **EPA, 1995a.** 《工业源复合体（ISC3）扩散模型用户指南，第 I 卷：用户说明》。EPA-454/B-95-003a。U.S. Environmental Protection Agency，Research Triangle Park, North Carolina 27711。
+
+6. **EPA, 1995b.** 《工业源复合体（ISC3）扩散模型用户指南，第 II 卷：模型算法说明》。EPA-454/B-95-003b。U.S. Environmental Protection Agency，Research Triangle Park, North Carolina 27711。
+
+7. **EPA, 2000.** 《法规模拟应用的气象监测指南》。EPA-454/R-99-005。U.S. Environmental Protection Agency，Research Triangle Park, North Carolina 27711。
+
+8. **EPA, 2003.** 《AERMOD 沉降算法——科学说明文件（修订草案）》。U.S. Environmental Protection Agency，Research Triangle Park, North Carolina 27711。
+
+9. **EPA, 2007.** 《AERMOD 模拟系统更新》。EPA Regional/State/Local Modelers Workshop 会议报告，Virginia Beach, Virginia。
+
+10. **EPA, 2008.** 《支持 NO₂ 一级国家环境空气质量标准审查的风险与暴露评估》。EPA-452/R-08-008a。U.S. Environmental Protection Agency，Research Triangle Park, North Carolina 27711。
+
+11. **EPA, 2010a.** 《证明符合 PM₂.₅ NAAQS 的模拟程序》。Stephen D. Page 备忘录，2010 年 3 月 23 日。U.S. Environmental Protection Agency，Research Triangle Park, North Carolina 27711。
+
+12. **EPA, 2010b.** 《附录 W 模拟指南对 1 小时 NO₂ 国家环境空气质量标准的适用性》。Tyler Fox 备忘录，2010 年 6 月 28 日。U.S. Environmental Protection Agency，Research Triangle Park, North Carolina 27711。
+
+13. **EPA, 2010c.** 《附录 W 模拟指南对 1 小时 SO₂ 国家环境空气质量标准的适用性》。Tyler Fox 备忘录，2010 年 8 月 23 日。U.S. Environmental Protection Agency，Research Triangle Park, North Carolina 27711。
+
+14. **EPA, 2011.** 《关于附录 W 模拟指南应用于 1 小时 NO₂ 国家环境空气质量标准的补充说明》。Tyler Fox 备忘录，2011 年 3 月 1 日。U.S. Environmental Protection Agency，Research Triangle Park, North Carolina 27711。
+
+15. **EPA, 2014a.** 《关于使用 AERMOD 扩散模拟证明符合 NO₂ 国家环境空气质量标准的说明》。Air Quality Modeling Group 备忘录，2014 年 9 月 30 日。U.S. Environmental Protection Agency，Research Triangle Park, North Carolina 27711。
+
+16. **EPA, 2014b.** 《PM₂.₅ 模拟指南》。2014 年 5 月 20 日，EPA-454/B-14-001。Office of Air Quality Planning & Standards，Research Triangle Park, North Carolina。
+
+17. **EPA, 2015.** 《与 NO₂ 有关的 AERMOD 修改技术支持文件》。2015 年 7 月，EPA-454/B-15-004。Office of Air Quality Planning & Standards，Research Triangle Park, North Carolina。
+
+<a id="ref-4-1-3"></a>
+
+### 4.1.3 EPA 2017—2023（18—25）
+
+18. **EPA, 2017a.** 《关于在 SO₂ 实施工作及其他法规行动中使用 AERMOD 模拟系统版本的说明》。AQAD 备忘录，2017 年 3 月 8 日。U.S. Environmental Protection Agency，Research Triangle Park, North Carolina 27711。
+
+19. **EPA, 2017b.** 《空气质量模型指南》，40 CFR Part 51 附录 W。U.S. Environmental Protection Agency，Research Triangle Park, North Carolina 27711。
+
+20. **EPA, 2018.** 《AERMOD 地形预处理程序（AERMAP）用户指南》。EPA-454/B-18-004。U.S. Environmental Protection Agency，Research Triangle Park, North Carolina 27711。
+
+21. **EPA, 2021.** 《AERSCREEN 用户指南》（2016 年 12 月）。EPA-454/B-21-005。Office of Air Quality Planning & Standards，Research Triangle Park, North Carolina。
+
+22. **EPA, 2023a.** 《AERMOD 模型理论与算法》。EPA-454/B-23-010。U.S. Environmental Protection Agency，Research Triangle Park, North Carolina 27711。
+
+23. **EPA, 2023b.** 《AERMOD 实施指南》（2022 年 6 月修订）。EPA-454/B-23-009。U.S. Environmental Protection Agency，Research Triangle Park, North Carolina 27711。
+
+24. **EPA, 2023c.** 《AERMOD 气象预处理程序（AERMET）用户指南》。EPA-454/B-23-005。U.S. Environmental Protection Agency，Research Triangle Park, North Carolina 27711。
+
+25. **EPA, 2023d.** 《面向移动源应用的 AERMOD RLINE 源类型纳入与评估》。EPA-2023/R-23-011。Office of Air Quality Planning and Standards，Research Triangle Park, North Carolina 27711。
+
+<a id="ref-4-2"></a>
+
+## 4.2 Hanna—Murray
+
+<a id="ref-4-2-1"></a>
+
+### 4.2.1 Hanna—Heist（26—29）
+
+26. **Hanna, S. R. and Dicristofaro, D. C., 1988.** 《OCD/API（海上与沿海扩散/美国石油学会）模型的开发与评估》。
+
+27. **Hanrahan, P. L., 1999a.** 《用于模拟中确定 NO₂/NOx 比值的烟羽体积摩尔比法，第 I 部分：方法》。*Journal of the Air & Waste Management Association*, 49, 1324–1331。
+
+28. **Hanrahan, P. L., 1999b.** 《用于模拟中确定 NO₂/NOx 比值的烟羽体积摩尔比法，第 II 部分：评估研究》。*Journal of the Air & Waste Management Association*, 49, 1332–1338。
+
+29. **Heist, D., Perry, S., Monbureau, E., Brouwer, L. and Brixey, L., 2016.** 《EPA/ORD 近期建筑物下洗研究概述》。2016 Regional, State, and Local Modelers’ Workshop，Research Triangle Park, North Carolina，2016 年 11 月 15—17 日。
+
+<a id="ref-4-2-2"></a>
+
+### 4.2.2 Luhar—Murray（30—32）
+
+30. **Luhar, A. K. and Rayner, K. N., 2009.** 《稳定层结条件下根据常规气象观测估算扩散应用所需动量和热量地表通量的方法》。*Boundary-Layer Meteorology*, 132, 437–454。
+
+31. **Monbureau, E. M., Heist, D. K., Perry, S. G., Brouwer, L. H., Foroutan, H. and Tang, W., 2018.** 《基于风洞和嵌套大涡模拟对 AERMOD 建筑物下洗算法的改进》。*Atmospheric Environment*, 179, 321–330。
+
+32. **Murray, D. R. and Bowne, N. E., 1988.** 《城市电厂烟羽研究》。EPRI Report No. EA 5468，Research Project 2736-1，Electric Power Research Institute，Palo Alto, California。
+
+<a id="ref-4-3"></a>
+
+## 4.3 Pandey—Yang
+
+<a id="ref-4-3-1"></a>
+
+### 4.3.1 Pandey—Petersen（33—37）
+
+33. **Pandey, G., Venkatram, A. and Arunachalam, S., 2023.** 《在 AERMOD 中考虑飞机排放烟羽抬升》。*Atmospheric Environment*, 314, 120106。DOI: `10.1016/j.atmosenv.2023.120106`。
+
+34. **Perry, S. G., Heist, D. K., Brouwer, L. H., Monbureau, E. M. and Brixley, L. A., 2016.** 《基于风洞模拟的狭长建筑物附近污染物扩散特征》。*Atmospheric Environment*, 42, 286–295。
+
+35. **Petersen, R. L., Guerra, S. A. and Bova, A. S., 2017.** 《AERMOD 建筑物下洗算法的批判性评述》。*Journal of the Air & Waste Management Association*, 67(8), 826–835。
+
+36. **Petersen, R. L. and Guerra, S. A., 2018.** 《PRIME2：矩形和流线型结构改进建筑物下洗算法的开发与评估》。*Journal of Wind Engineering and Industrial Aerodynamics*, 173, 67–78。
+
+37. **Petersen, R. L., 1984.** 《海上石油平台排放扩散——风洞模拟评估》。API Publication No. 4402。
+
+<a id="ref-4-3-2"></a>
+
+### 4.3.2 Qian—Snyder（38—42）
+
+38. **Qian, W. and Venkatram, A., 2011.** 《低风速条件下稳态扩散模型的性能》。*Boundary-Layer Meteorology*, 138, 475–491。
+
+39. **Schulman, L. L. and Scire, J. S., 1980.** 《浮力线源与点源（BLP）扩散模型用户指南》。Final Report，Environmental Research & Technology, Inc.，P-7304B。
+
+40. **Schulman, L. L., Strimaitis, D. G. and Scire, J. S., 2000.** 《PRIME 烟羽抬升与建筑物下洗模型的开发和评估》。*Journal of the Air & Waste Management Association*, 50, 378–390。
+
+41. **Snyder, M. G., Venkatram, A., Heist, D. K., Perry, S. G., Petersen, W. B. and Isakov, V., 2013.** 《RLINE：用于近地面释放的线源扩散模型》。*Atmospheric Environment*, 77, 748–756。
+
+42. **Snyder, M. G. and Heist, D., 2013.** 《R-LINE 模型 1.2 版用户指南：用于近地面释放的研究型线源模型》。EPA-MD-81。U.S. Environmental Protection Agency，Research Triangle Park, North Carolina 27711。
+
+<a id="ref-4-3-3"></a>
+
+### 4.3.3 Venkatram—Yang（43—48）
+
+43. **Venkatram, A., Karamchandani, P., Pai, P. and Goldstein, R., 1994.** 《简化臭氧模拟系统（SOMS）的开发与应用》。*Atmospheric Environment*, 28(22), 3365–3678。DOI: `10.1016/1352-2310(94)00190-V`。
+
+44. **Walcek, C., Stensland, G., Zhang, L., Huang, H., Hales, J., Sweet, C., Massman, W., Williams, A. and Dicke, J., 2001.** 《“工业源复合体（ISC3）模型沉降参数化”报告的科学同行评审》。The KEVRIC Company，Durham, North Carolina。
+
+45. **Warren, C. J., Paine, R. J., Connors, J. A., Szembek, C. and Knipping, E., 2022.** 《AERMOD 对白天高架稳定层中烟羽扩散修订处理的评估》。*Journal of the Air & Waste Management Association*, 72(9), 1040–1052。DOI: `10.1080/10962247.2022.2094031`。
+
+46. **Weil, J. C., 2020.** 《对流边界层中高浮力烟羽的新扩散模型》。提交 Western Australia Department of Environmental Conservation 的模拟报告。
+
+47. **Wesely, M. L., Doskey, P. V. and Shannon, J. D., 2002.** 《工业源复合体（ISC3）模型的沉降参数化》。Draft ANL Report ANL/ER/TRB01/003，Argonne National Laboratory，Argonne, Illinois 60439。
+
+48. **Yang, B., Gu, J. and Zhang, K. M., 2020.** 《采用混合模型参数化建筑物下洗和侧洗效应》。*Building and Environment*, 172, 106694。
+
+---
+
+**原文注：** 上述许多参考文献可通过美国 EPA 的 SCRAM 网站获得。本站另设有[官方资源页](/resources/)，用于集中访问 EPA 与 AERMOD 相关入口。

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "docs:dev": "vuepress dev docs",
-    "docs:check": "node scripts/check-docs.mjs && node scripts/check-appendix-c.mjs && node scripts/check-chapter3-co.mjs && node scripts/check-chapter3-so.mjs && node scripts/check-chapter3-re.mjs && node scripts/check-chapter3-me.mjs && node scripts/check-chapter3-ev.mjs && node scripts/check-chapter3-ou.mjs",
+    "docs:check": "node scripts/check-docs.mjs && node scripts/check-appendix-c.mjs && node scripts/check-chapter3-co.mjs && node scripts/check-chapter3-so.mjs && node scripts/check-chapter3-re.mjs && node scripts/check-chapter3-me.mjs && node scripts/check-chapter3-ev.mjs && node scripts/check-chapter3-ou.mjs && node scripts/check-chapter4-references.mjs",
     "docs:build": "vuepress build docs"
   },
   "keywords": [],

--- a/scripts/check-chapter4-references.mjs
+++ b/scripts/check-chapter4-references.mjs
@@ -1,0 +1,67 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const refPath = resolve('docs/guide/04-references.md')
+const sidebarPath = resolve('docs/.vuepress/guide-sidebar.js')
+const errors = []
+
+if (!existsSync(refPath)) {
+  errors.push('缺少第4章参考文献页面：docs/guide/04-references.md')
+} else {
+  const text = readFileSync(refPath, 'utf8')
+  if (text.length < 7500) errors.push(`第4章参考文献内容量异常：${text.length} 字符`)
+
+  const numbers = [...text.matchAll(/^(\d+)\.\s+\*\*/gm)].map((match) => Number(match[1]))
+  if (numbers.length !== 48) {
+    errors.push(`第4章参考文献条目数量异常：${numbers.length}，应为 48`)
+  } else {
+    for (let i = 0; i < 48; i += 1) {
+      if (numbers[i] !== i + 1) {
+        errors.push(`第4章参考文献编号异常：第 ${i + 1} 个条目编号为 ${numbers[i]}`)
+        break
+      }
+    }
+  }
+
+  const anchors = [
+    'ref-4-1', 'ref-4-1-1', 'ref-4-1-2', 'ref-4-1-3',
+    'ref-4-2', 'ref-4-2-1', 'ref-4-2-2',
+    'ref-4-3', 'ref-4-3-1', 'ref-4-3-2', 'ref-4-3-3',
+  ]
+  for (const anchor of anchors) {
+    const marker = `id="${anchor}"`
+    const count = text.split(marker).length - 1
+    if (count !== 1) errors.push(`第4章目录锚点数量异常：${anchor}（${count}）`)
+  }
+
+  for (const marker of [
+    'EPA, 2023d.',
+    'Pandey, G., Venkatram, A. and Arunachalam, S., 2023.',
+    'Warren, C. J., Paine, R. J.',
+    'Yang, B., Gu, J. and Zhang, K. M., 2020.',
+    '10.1080/10962247.2022.2094031',
+  ]) {
+    if (!text.includes(marker)) errors.push(`第4章参考文献缺少关键标记：${marker}`)
+  }
+}
+
+if (!existsSync(sidebarPath)) {
+  errors.push('缺少用户指南侧栏配置')
+} else {
+  const sidebar = readFileSync(sidebarPath, 'utf8')
+  for (const anchor of [
+    '#ref-4-1', '#ref-4-1-1', '#ref-4-1-2', '#ref-4-1-3',
+    '#ref-4-2', '#ref-4-2-1', '#ref-4-2-2',
+    '#ref-4-3', '#ref-4-3-1', '#ref-4-3-2', '#ref-4-3-3',
+  ]) {
+    if (!sidebar.includes(anchor)) errors.push(`第4章侧栏缺少链接：${anchor}`)
+  }
+}
+
+if (errors.length) {
+  console.error('\n第4章参考文献完整性检查失败：')
+  for (const error of errors) console.error(`- ${error}`)
+  process.exit(1)
+}
+
+console.log('第4章参考文献完整性检查通过：48 条文献，11 个稳定目录锚点。')


### PR DESCRIPTION
## 修改内容

- 将第4章现有10条代表性文献替换为英文原文第4-1—4-5页的48条完整参考文献；
- 保留原文排列顺序与编号1—48；
- 按作者/机构字母顺序建立4.1—4.3及8个三级目录小节，避免人为主题分类打乱原文顺序；
- 补充AERSCREEN原文日期、AERMOD实施指南修订信息、会议日期及3条DOI；
- 将第4章侧栏统一为章—节—小节三级结构，并使用11个稳定锚点；
- 增加条目数量、编号连续性、关键文献、锚点及侧栏链接防退化检查。

## 来源范围

对应EPA 2023版AERMOD用户指南第4章完整中文译稿，英文原文印刷页码4-1至4-5。