### PR TITLE
docs: 复核附录B并展开三级目录

### DIFF
--- a/docs/.vuepress/appendix-sidebar.js
+++ b/docs/.vuepress/appendix-sidebar.js
@@ -1,175 +1,91 @@
+const leaf = (text, link) => ({ text, link })
+const group = (text, link, children) => ({ text, link, collapsible: true, children })
+
 export const appendixSidebar = [
-  { text: '附录导读', link: '/appendices/' },
-  {
-    text: '附录 A　功能性关键字/参数参考',
-    link: '/appendices/appendix-a.html',
-    collapsible: true,
-    children: [
-      { text: 'A.1　使用说明', link: '/appendices/appendix-a-01-usage.html' },
-      {
-        text: 'A.2　CO 控制路径',
-        link: '/appendices/appendix-a-02-co.html',
-        collapsible: true,
-        children: [
-          { text: '表 A-1　控制路径关键字', link: '/appendices/appendix-a-02-co.html#table-a-1' },
-          { text: '表 A-2　关键字和参数', link: '/appendices/appendix-a-02-co.html#table-a-2' },
-        ],
-      },
-      {
-        text: 'A.3　SO 污染源路径',
-        link: '/appendices/appendix-a-03-so.html',
-        collapsible: true,
-        children: [
-          { text: '表 A-3　污染源路径关键字', link: '/appendices/appendix-a-03-so.html#table-a-3' },
-          { text: '表 A-4　关键字和参数', link: '/appendices/appendix-a-03-so.html#table-a-4' },
-        ],
-      },
-      {
-        text: 'A.4　RE 受体路径',
-        link: '/appendices/appendix-a-04-re.html',
-        collapsible: true,
-        children: [
-          { text: '表 A-5　受体路径关键字', link: '/appendices/appendix-a-04-re.html#table-a-5' },
-          { text: '表 A-6　关键字和参数', link: '/appendices/appendix-a-04-re.html#table-a-6' },
-        ],
-      },
-      {
-        text: 'A.5　ME 气象路径',
-        link: '/appendices/appendix-a-05-me.html',
-        collapsible: true,
-        children: [
-          { text: '表 A-7　气象路径关键字', link: '/appendices/appendix-a-05-me.html#table-a-7' },
-          { text: '表 A-8　关键字和参数', link: '/appendices/appendix-a-05-me.html#table-a-8' },
-        ],
-      },
-      {
-        text: 'A.6　EV 事件路径',
-        link: '/appendices/appendix-a-06-ev.html',
-        collapsible: true,
-        children: [
-          { text: '表 A-9　事件路径关键字', link: '/appendices/appendix-a-06-ev.html#table-a-9' },
-          { text: '表 A-10　关键字和参数', link: '/appendices/appendix-a-06-ev.html#table-a-10' },
-        ],
-      },
-      {
-        text: 'A.7　OU 输出路径',
-        link: '/appendices/appendix-a-07-ou.html',
-        collapsible: true,
-        children: [
-          { text: '表 A-11　输出路径关键字', link: '/appendices/appendix-a-07-ou.html#table-a-11' },
-          { text: '表 A-12　关键字和参数', link: '/appendices/appendix-a-07-ou.html#table-a-12' },
-        ],
-      },
-      { text: 'A.8　路径结束语句', link: '/appendices/appendix-a-08-finish.html' },
-    ],
-  },
-  { text: '附录 B　错误消息代码', link: '/appendices/appendix-b.html' },
-  {
-    text: '附录 C　文件格式说明',
-    link: '/appendices/appendix-c.html',
-    collapsible: true,
-    children: [
-      {
-        text: 'C.1　AERMET 气象数据',
-        link: '/appendices/appendix-c-01.html',
-        collapsible: true,
-        children: [
-          { text: 'C.1.1　SURFACE OUTPUT', link: '/appendices/appendix-c-01.html#c-1-1-surface-output' },
-          { text: 'C.1.2　PROFILE OUTPUT', link: '/appendices/appendix-c-01.html#c-1-2-profile-output' },
-        ],
-      },
-      {
-        text: 'C.2　MAXIFILE',
-        link: '/appendices/appendix-c-02.html',
-        collapsible: true,
-        children: [
-          { text: 'C.2.1　文件结构与字段', link: '/appendices/appendix-c-02.html#c-2-1-文件结构与字段' },
-          { text: 'C.2.2　示例', link: '/appendices/appendix-c-02.html#c-2-2-示例' },
-        ],
-      },
-      {
-        text: 'C.3　POSTFILE',
-        link: '/appendices/appendix-c-03.html',
-        collapsible: true,
-        children: [
-          { text: 'C.3.1　未格式化 POSTFILE', link: '/appendices/appendix-c-03.html#c-3-1-未格式化-postfile' },
-          { text: 'C.3.2　格式化 POSTFILE', link: '/appendices/appendix-c-03.html#c-3-2-格式化-postfile' },
-        ],
-      },
-      {
-        text: 'C.4　PLOTFILE',
-        link: '/appendices/appendix-c-04.html',
-        collapsible: true,
-        children: [
-          { text: 'C.4.1　文件结构与字段', link: '/appendices/appendix-c-04.html#c-4-1-文件结构与字段' },
-          { text: 'C.4.2　示例与最大值标记', link: '/appendices/appendix-c-04.html#c-4-2-示例与最大值标记' },
-        ],
-      },
-      {
-        text: 'C.5　TOXXFILE',
-        link: '/appendices/appendix-c-05.html',
-        collapsible: true,
-        children: [
-          { text: 'C.5.1　文件头记录', link: '/appendices/appendix-c-05.html#c-5-1-文件头记录' },
-          { text: 'C.5.2　数据记录与标识变量', link: '/appendices/appendix-c-05.html#c-5-2-数据记录与标识变量' },
-        ],
-      },
-      {
-        text: 'C.6　RANKFILE',
-        link: '/appendices/appendix-c-06.html',
-        collapsible: true,
-        children: [
-          { text: 'C.6.1　文件结构与字段', link: '/appendices/appendix-c-06.html#c-6-1-文件结构与字段' },
-          { text: 'C.6.2　示例', link: '/appendices/appendix-c-06.html#c-6-2-示例' },
-        ],
-      },
-      {
-        text: 'C.7　EVALFILE',
-        link: '/appendices/appendix-c-07.html',
-        collapsible: true,
-        children: [
-          { text: 'C.7.1　适用范围与输出变量', link: '/appendices/appendix-c-07.html#c-7-1-适用范围与输出变量' },
-          { text: 'C.7.2　Fortran 输出格式', link: '/appendices/appendix-c-07.html#c-7-2-fortran-输出格式' },
-        ],
-      },
-      {
-        text: 'C.8　SEASONHR',
-        link: '/appendices/appendix-c-08.html',
-        collapsible: true,
-        children: [
-          { text: 'C.8.1　文件结构与字段', link: '/appendices/appendix-c-08.html#c-8-1-文件结构与字段' },
-          { text: 'C.8.2　季节索引与示例', link: '/appendices/appendix-c-08.html#c-8-2-季节索引与示例' },
-        ],
-      },
-      {
-        text: 'C.9　MAXDCONT',
-        link: '/appendices/appendix-c-09.html',
-        collapsible: true,
-        children: [
-          { text: 'C.9.1　文件结构与字段', link: '/appendices/appendix-c-09.html#c-9-1-文件结构与字段' },
-          { text: 'C.9.2　排序组织与示例', link: '/appendices/appendix-c-09.html#c-9-2-排序组织与示例' },
-        ],
-      },
-      {
-        text: 'C.10　MAXDAILY',
-        link: '/appendices/appendix-c-10.html',
-        collapsible: true,
-        children: [
-          { text: 'C.10.1　文件结构与字段', link: '/appendices/appendix-c-10.html#c-10-1-文件结构与字段' },
-          { text: 'C.10.2　示例', link: '/appendices/appendix-c-10.html#c-10-2-示例' },
-        ],
-      },
-      {
-        text: 'C.11　MXDYBYYR',
-        link: '/appendices/appendix-c-11.html',
-        collapsible: true,
-        children: [
-          { text: 'C.11.1　文件结构与字段', link: '/appendices/appendix-c-11.html#c-11-1-文件结构与字段' },
-          { text: 'C.11.2　排序组织与示例', link: '/appendices/appendix-c-11.html#c-11-2-排序组织与示例' },
-        ],
-      },
-    ],
-  },
-  { text: '附录 D　23132 版本修订', link: '/appendices/appendix-d.html' },
-  { text: '附录 E　术语表', link: '/appendices/appendix-e.html' },
+  leaf('附录导读', '/appendices/'),
+  group('附录 A　功能性关键字/参数参考', '/appendices/appendix-a.html', [
+    leaf('A.1　使用说明', '/appendices/appendix-a-01-usage.html'),
+    group('A.2　CO 控制路径', '/appendices/appendix-a-02-co.html', [
+      leaf('表 A-1　控制路径关键字', '/appendices/appendix-a-02-co.html#table-a-1'),
+      leaf('表 A-2　关键字和参数', '/appendices/appendix-a-02-co.html#table-a-2'),
+    ]),
+    group('A.3　SO 污染源路径', '/appendices/appendix-a-03-so.html', [
+      leaf('表 A-3　污染源路径关键字', '/appendices/appendix-a-03-so.html#table-a-3'),
+      leaf('表 A-4　关键字和参数', '/appendices/appendix-a-03-so.html#table-a-4'),
+    ]),
+    group('A.4　RE 受体路径', '/appendices/appendix-a-04-re.html', [
+      leaf('表 A-5　受体路径关键字', '/appendices/appendix-a-04-re.html#table-a-5'),
+      leaf('表 A-6　关键字和参数', '/appendices/appendix-a-04-re.html#table-a-6'),
+    ]),
+    group('A.5　ME 气象路径', '/appendices/appendix-a-05-me.html', [
+      leaf('表 A-7　气象路径关键字', '/appendices/appendix-a-05-me.html#table-a-7'),
+      leaf('表 A-8　关键字和参数', '/appendices/appendix-a-05-me.html#table-a-8'),
+    ]),
+    group('A.6　EV 事件路径', '/appendices/appendix-a-06-ev.html', [
+      leaf('表 A-9　事件路径关键字', '/appendices/appendix-a-06-ev.html#table-a-9'),
+      leaf('表 A-10　关键字和参数', '/appendices/appendix-a-06-ev.html#table-a-10'),
+    ]),
+    group('A.7　OU 输出路径', '/appendices/appendix-a-07-ou.html', [
+      leaf('表 A-11　输出路径关键字', '/appendices/appendix-a-07-ou.html#table-a-11'),
+      leaf('表 A-12　关键字和参数', '/appendices/appendix-a-07-ou.html#table-a-12'),
+    ]),
+    leaf('A.8　路径结束语句', '/appendices/appendix-a-08-finish.html'),
+  ]),
+  group('附录 B　错误消息代码', '/appendices/appendix-b.html', [
+    leaf('B.1　引言', '/appendices/appendix-b.html#b-1-引言'),
+    leaf('B.2　输出消息汇总', '/appendices/appendix-b.html#b-2-输出消息汇总'),
+    group('B.3　消息布局说明', '/appendices/appendix-b.html#b-3-消息布局说明', [
+      leaf('B.3.1　消息的统一结构', '/appendices/appendix-b.html#b-3-1-消息的统一结构'),
+      leaf('B.3.2　消息字段与列位置', '/appendices/appendix-b.html#b-3-2-消息字段与列位置'),
+      leaf('B.3.3　INCLUDED 外部文件中的行号', '/appendices/appendix-b.html#b-3-3-included-外部文件中的行号'),
+    ]),
+  ]),
+  group('附录 C　文件格式说明', '/appendices/appendix-c.html', [
+    group('C.1　AERMET 气象数据', '/appendices/appendix-c-01.html', [
+      leaf('C.1.1　SURFACE OUTPUT', '/appendices/appendix-c-01.html#c-1-1-surface-output'),
+      leaf('C.1.2　PROFILE OUTPUT', '/appendices/appendix-c-01.html#c-1-2-profile-output'),
+    ]),
+    group('C.2　MAXIFILE', '/appendices/appendix-c-02.html', [
+      leaf('C.2.1　文件结构与字段', '/appendices/appendix-c-02.html#c-2-1-文件结构与字段'),
+      leaf('C.2.2　示例', '/appendices/appendix-c-02.html#c-2-2-示例'),
+    ]),
+    group('C.3　POSTFILE', '/appendices/appendix-c-03.html', [
+      leaf('C.3.1　未格式化 POSTFILE', '/appendices/appendix-c-03.html#c-3-1-未格式化-postfile'),
+      leaf('C.3.2　格式化 POSTFILE', '/appendices/appendix-c-03.html#c-3-2-格式化-postfile'),
+    ]),
+    group('C.4　PLOTFILE', '/appendices/appendix-c-04.html', [
+      leaf('C.4.1　文件结构与字段', '/appendices/appendix-c-04.html#c-4-1-文件结构与字段'),
+      leaf('C.4.2　示例与最大值标记', '/appendices/appendix-c-04.html#c-4-2-示例与最大值标记'),
+    ]),
+    group('C.5　TOXXFILE', '/appendices/appendix-c-05.html', [
+      leaf('C.5.1　文件头记录', '/appendices/appendix-c-05.html#c-5-1-文件头记录'),
+      leaf('C.5.2　数据记录与标识变量', '/appendices/appendix-c-05.html#c-5-2-数据记录与标识变量'),
+    ]),
+    group('C.6　RANKFILE', '/appendices/appendix-c-06.html', [
+      leaf('C.6.1　文件结构与字段', '/appendices/appendix-c-06.html#c-6-1-文件结构与字段'),
+      leaf('C.6.2　示例', '/appendices/appendix-c-06.html#c-6-2-示例'),
+    ]),
+    group('C.7　EVALFILE', '/appendices/appendix-c-07.html', [
+      leaf('C.7.1　适用范围与输出变量', '/appendices/appendix-c-07.html#c-7-1-适用范围与输出变量'),
+      leaf('C.7.2　Fortran 输出格式', '/appendices/appendix-c-07.html#c-7-2-fortran-输出格式'),
+    ]),
+    group('C.8　SEASONHR', '/appendices/appendix-c-08.html', [
+      leaf('C.8.1　文件结构与字段', '/appendices/appendix-c-08.html#c-8-1-文件结构与字段'),
+      leaf('C.8.2　季节索引与示例', '/appendices/appendix-c-08.html#c-8-2-季节索引与示例'),
+    ]),
+    group('C.9　MAXDCONT', '/appendices/appendix-c-09.html', [
+      leaf('C.9.1　文件结构与字段', '/appendices/appendix-c-09.html#c-9-1-文件结构与字段'),
+      leaf('C.9.2　排序组织与示例', '/appendices/appendix-c-09.html#c-9-2-排序组织与示例'),
+    ]),
+    group('C.10　MAXDAILY', '/appendices/appendix-c-10.html', [
+      leaf('C.10.1　文件结构与字段', '/appendices/appendix-c-10.html#c-10-1-文件结构与字段'),
+      leaf('C.10.2　示例', '/appendices/appendix-c-10.html#c-10-2-示例'),
+    ]),
+    group('C.11　MXDYBYYR', '/appendices/appendix-c-11.html', [
+      leaf('C.11.1　文件结构与字段', '/appendices/appendix-c-11.html#c-11-1-文件结构与字段'),
+      leaf('C.11.2　排序组织与示例', '/appendices/appendix-c-11.html#c-11-2-排序组织与示例'),
+    ]),
+  ]),
+  leaf('附录 D　23132 版本修订', '/appendices/appendix-d.html'),
+  leaf('附录 E　术语表', '/appendices/appendix-e.html'),
 ]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "docs:dev": "vuepress dev docs",
-    "docs:check": "node scripts/check-docs.mjs && node scripts/check-appendix-c.mjs && node scripts/check-chapter3-co.mjs && node scripts/check-chapter3-so.mjs && node scripts/check-chapter3-re.mjs && node scripts/check-chapter3-me.mjs && node scripts/check-chapter3-ev.mjs && node scripts/check-chapter3-ou.mjs && node scripts/check-chapter4-references.mjs && node scripts/check-appendix-a.mjs",
+    "docs:check": "node scripts/check-docs.mjs && node scripts/check-appendix-c.mjs && node scripts/check-chapter3-co.mjs && node scripts/check-chapter3-so.mjs && node scripts/check-chapter3-re.mjs && node scripts/check-chapter3-me.mjs && node scripts/check-chapter3-ev.mjs && node scripts/check-chapter3-ou.mjs && node scripts/check-chapter4-references.mjs && node scripts/check-appendix-a.mjs && node scripts/check-appendix-b.mjs",
     "docs:build": "vuepress build docs"
   },
   "keywords": [],

--- a/scripts/check-appendix-b.mjs
+++ b/scripts/check-appendix-b.mjs
@@ -1,0 +1,68 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const pagePath = resolve('docs/appendices/appendix-b.md')
+const sidebarPath = resolve('docs/.vuepress/appendix-sidebar.js')
+const errors = []
+
+if (!existsSync(pagePath)) {
+  errors.push('缺少附录B页面：docs/appendices/appendix-b.md')
+} else {
+  const text = readFileSync(pagePath, 'utf8')
+  if (text.length < 3600) errors.push(`附录B内容量异常：${text.length}字符`)
+
+  for (const marker of [
+    '## B.1 引言',
+    '## B.2 输出消息汇总',
+    '## B.3 消息布局说明',
+    '## B.3.1 消息的统一结构',
+    '## B.3.2 消息字段与列位置',
+    '## B.3.3 INCLUDED 外部文件中的行号',
+    'SETUP Finishes Successfully.',
+    'CO E1008 EXPATH: Invalid Pathway Specified.',
+    'PW Txxx LLLL mmmmmm: MESSAGE Hints',
+    '| `PW` | 1–2 |',
+    '| `T` | 4 |',
+    '| `xxx` | 5–7 |',
+    '| `LLLL` | 9–12 |',
+    '| `mmmmmm` | 14–19 |',
+    '| `MESSAGE` | 22–71 |',
+    '| `Hints` | 73–80 |',
+    '外部引入文件中的行号',
+  ]) {
+    if (!text.includes(marker)) errors.push(`附录B缺少关键内容：${marker}`)
+  }
+
+  for (const type of ['`E` | 错误', '`W` | 警告', '`I` | 信息']) {
+    if (!text.includes(type)) errors.push(`附录B缺少消息类型：${type}`)
+  }
+
+  const codeBlocks = (text.match(/^```/gm) || []).length
+  if (codeBlocks < 14 || codeBlocks % 2 !== 0) {
+    errors.push(`附录B代码块围栏异常：${codeBlocks}`)
+  }
+}
+
+if (!existsSync(sidebarPath)) {
+  errors.push('缺少附录侧栏配置')
+} else {
+  const sidebar = readFileSync(sidebarPath, 'utf8')
+  for (const link of [
+    '#b-1-引言',
+    '#b-2-输出消息汇总',
+    '#b-3-消息布局说明',
+    '#b-3-1-消息的统一结构',
+    '#b-3-2-消息字段与列位置',
+    '#b-3-3-included-外部文件中的行号',
+  ]) {
+    if (!sidebar.includes(link)) errors.push(`附录B侧栏缺少链接：${link}`)
+  }
+}
+
+if (errors.length) {
+  console.error('\n附录B完整性检查失败：')
+  for (const error of errors) console.error(`- ${error}`)
+  process.exit(1)
+}
+
+console.log('附录B完整性检查通过：B.1—B.3.3内容、消息字段及三级侧栏完整。')


### PR DESCRIPTION
## 修改内容

- 复核附录B B.1—B.3.3完整中文内容；
- 将附录B侧栏从单一入口展开为B.1、B.2、B.3及B.3.1—B.3.3三级结构；
- 保留并检查E/W/I三类消息、E100示例、统一消息布局和七个字段列位置；
- 检查INCLUDED外部文件中的行号报告规则；
- 新增附录B内容量、标题、代码围栏、字段及侧栏链接防退化检查；
- 使用leaf/group辅助函数简化附录侧栏配置，保留附录A和C全部原有链接。

## 来源范围

对应EPA 2023版AERMOD用户指南附录B完整中文译稿，英文原文印刷页码B-1至B-4。